### PR TITLE
Allow the use of 3rd party ntp modules

### DIFF
--- a/manifests/ntp.pp
+++ b/manifests/ntp.pp
@@ -49,7 +49,7 @@ class system::ntp (
       }
     }
     else {
-      class { '::ntp': }
+      include '::ntp'
     }
   }
 }


### PR DESCRIPTION
Helps avoid in this case 'Duplicate declaration: Class[Ntp] is already declared' if an ntp module was loaded elsewhere.
