### PR TITLE
Provide default empty hashes to create_resources call

### DIFF
--- a/manifests/augeas.pp
+++ b/manifests/augeas.pp
@@ -1,5 +1,5 @@
 class system::augeas (
-  $config   = undef,
+  $config   = {},
   $schedule = $::system::schedule,
 ) {
   $defaults = {
@@ -9,7 +9,7 @@ class system::augeas (
     create_resources(augeas, $config, $defaults)
   }
   else {
-    $hiera_config = hiera_hash('system::augeas', undef)
+    $hiera_config = hiera_hash('system::augeas', {})
     if $hiera_config {
       create_resources(augeas, $hiera_config, $defaults)
     }


### PR DESCRIPTION
as newer versions of Puppet enforce it - create_resources(): second argument must be a hash
