### PR TITLE
add ability to invoke file_line via hiera

### DIFF
--- a/manifests/file_lines.pp
+++ b/manifests/file_lines.pp
@@ -1,0 +1,20 @@
+
+class system::file_lines (
+  $config   = undef,
+  $schedule = $::system::schedule,
+) {
+  $defaults = {
+    ensure   => 'present',
+    schedule => $schedule,
+  }
+  if $config {
+    create_resources(file_lines, $config, $defaults)
+  }
+  else {
+    $hiera_config = hiera_hash('system::file_lines', undef)
+    if $hiera_config {
+      create_resources(file_line, $hiera_config, $defaults)
+    }
+  }
+}
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,11 @@ class system (
     stage  => third,
   }
 
+  class { '::system::file_lines':
+    config => $config['file_lines'],
+    stage => third,
+  }
+
   class { '::system::groups':
     config => $config['groups'],
     stage  => second


### PR DESCRIPTION
This PR adds the ability to create `file_lines` resources via the familiar `system::<resource>` approach. Tis allows easy appending of lines to files for example:

```
system::file_lines:
  'add-hook-into-thing':
    path: /my/file.script.sh
    line: '[ -x /my/script ] && /my/script' 
```

The above adds (appends) the defined `line:` contents `[ -x /my/script ] && /my/script` to the file located at `/my/file.script.sh` and uses the puppet resource name of `add-hook-into-thing`.

Anything in excess of adding lines to files should be avoided and instead use ageas and an appropriate lens.

**note:** that file_lines is now in the stdlib module and as such is a dependency of these changes
