### PR TITLE
add system:: manifests for file_line usage

### DIFF
--- a/manifests/file_lines.pp
+++ b/manifests/file_lines.pp
@@ -1,0 +1,20 @@
+
+class system::file_lines (
+  $config   = undef,
+  $schedule = $::system::schedule,
+) {
+  $defaults = {
+    ensure   => 'present',
+    schedule => $schedule,
+  }
+  if $config {
+    create_resources(file_lines, $config, $defaults)
+  }
+  else {
+    $hiera_config = hiera_hash('system::file_lines', undef)
+    if $hiera_config {
+      create_resources(file_line, $hiera_config, $defaults)
+    }
+  }
+}
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,11 @@ class system (
     stage  => third,
   }
 
+  class { '::system::file_lines':
+    config => $config['file_lines'],
+    stage => third,
+  }
+
   class { '::system::groups':
     config => $config['groups'],
     stage  => second


### PR DESCRIPTION
 it fits in with the system:: pattern of usage in hiera  so to use `system::file_lines`  this adds the manifests
