### PR TITLE
Remove all `include augeasproviders` lines

### DIFF
--- a/manifests/providers.pp
+++ b/manifests/providers.pp
@@ -12,11 +12,9 @@ class system::providers (
       Host { provider => 'augeas' }
     }
     if $config['mailalias'] == 'augeas' {
-      include augeasproviders
       Mailalias { provider => 'augeas' }
     }
     if $config['mounttab'] == 'augeas' {
-      include augeasproviders
       Mounttab { provider => 'augeas' }
     }
   }

--- a/manifests/sshd.pp
+++ b/manifests/sshd.pp
@@ -7,13 +7,11 @@ class system::sshd (
     schedule => $sys_schedule,
   }
   if $config {
-    include augeasproviders
     create_resources(sshd_config, $config, $defaults)
   }
   else {
     $hiera_config = hiera_hash('system::sshd', undef)
     if $hiera_config {
-      include augeasproviders
       create_resources(sshd_config, $hiera_config, $defaults)
     }
   }

--- a/manifests/sshd/subsystem.pp
+++ b/manifests/sshd/subsystem.pp
@@ -2,7 +2,6 @@ class system::sshd::subsystem (
   $config = undef
 ) {
   if $config {
-    include augeasproviders
     $defaults = {}
     create_resources(sshd_config_subsystem, $config, $defaults)
   }

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -6,13 +6,11 @@ class system::sysctl (
     schedule => $sys_schedule,
   }
   if $config {
-    include augeasproviders
     create_resources(sysctl, $config, $defaults)
   }
   else {
     $hiera_config = hiera_hash('system::sysctl', undef)
     if $hiera_config {
-      include augeasproviders
       create_resources(sysctl, $hiera_config, $defaults)
     }
   }


### PR DESCRIPTION
add dependencies herculesteam/augeasproviders_core, herculesteam/augeasproviders_sysctl

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
add new  augeasproviders_core, augeasproviders_sysctl modules and remove include augeasproviders function in sysctl.pp

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #72 
-->
